### PR TITLE
Added capability to add comma-separated namespaces for a multi-namesp…

### DIFF
--- a/check_k8s.py
+++ b/check_k8s.py
@@ -22,37 +22,41 @@ def main():
 
     health_check, is_core = MAPPINGS[parsed.resource]
 
-    # Build URL using input arguments
-    url = build_url(
-        host=parsed.host,
-        port=parsed.port,
-        resource=parsed.resource,
-        is_core=is_core,
-        namespace=parsed.namespace
-    )
+    response = []
+    for i in parsed.namespace.split(","):
 
+      # Build URL using input arguments
+      url = build_url(
+          host=parsed.host,
+          port=parsed.port,
+          resource=parsed.resource,
+          is_core=is_core,
+          namespace=i
+      )
     # Request and check health data
-    try:
-        response, status = request(url, token=parsed.token, insecure=parsed.insecure)
-        output = health_check(response).output
-        if not isinstance(output, Output):
-            raise TypeError("Unknown health check format")
-    except HTTPError as e:
-        body = json.loads(e.read().decode("utf8"))
-        output = Output(
-            NaemonState.UNKNOWN,
-            "{0}: {1}".format(e.code, body.get("message")),
-            sys.stdout
-        )
-    except URLError as e:
-        output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
-    except Exception as e:
-        if parsed.debug:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            traceback.print_tb(exc_traceback, file=sys.stdout)
+      try:
+          response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
+          response.extend(response_single);
+      except HTTPError as e:
+          body = json.loads(e.read().decode("utf8"))
+          output = Output(
+              NaemonState.UNKNOWN,
+              "{0}: {1}".format(e.code, body.get("message")),
+              sys.stdout
+          )
+      except URLError as e:
+          output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
+      except Exception as e:
+          if parsed.debug:
+              exc_type, exc_value, exc_traceback = sys.exc_info()
+              traceback.print_tb(exc_traceback, file=sys.stdout)
+          output = Output(NaemonState.UNKNOWN, e, sys.stdout)
 
-        output = Output(NaemonState.UNKNOWN, e, sys.stdout)
 
+
+    output = health_check(response).output
+    if not isinstance(output, Output):
+      raise TypeError("Unknown health check format")
     msg = NAGIOS_MSG.format(state=output.state.name, message=output.message)
     output.channel.write(msg)
     sys.exit(output.state.value)

--- a/k8s/components/pod/resource.py
+++ b/k8s/components/pod/resource.py
@@ -41,6 +41,10 @@ class Pod(Resource):
         elif cnd_type in STATUSES:
             if cnd_status == "True":
                 return NaemonStatus(NaemonState.OK, self.perf.AVAILABLE)
+            # YV - adding this when the phase is Succeeded
+            # This happens when the pod is not running since it's already completed
+            elif cnd_status and self.phase == Phase.succeeded:
+                return NaemonStatus(NaemonState.OK, self.perf.AVAILABLE)
             else:
                 return NaemonStatus(NaemonState.CRITICAL, self.perf.UNAVAILABLE)
         elif cnd_type not in STATUSES and cnd_status == "True":


### PR DESCRIPTION
…ace check (necessary for projects like Babylon where a single application is spread across multiple namespaces) as such:

--namespace "namespace1,namespace2,namespace3"
Additional fix added by yvarbanov for acknowledging pods in "Completed" as successful - the script was reporting those as failed, incorrectly